### PR TITLE
Minimum og noekler må ha egen namespace 

### DIFF
--- a/KS.Fiks.Arkiv.XsdModelGenerator/Generate.cs
+++ b/KS.Fiks.Arkiv.XsdModelGenerator/Generate.cs
@@ -55,19 +55,19 @@ var generator = new Generator
         },
         {
             new NamespaceKey("http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/minimum/v1"),
-            commonNamespace + ".Arkivstruktur"
+            commonNamespace + ".Arkivstruktur.Minimum"
         },
         {
             new NamespaceKey("https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/minimum/v1"),
-            commonNamespace + ".Arkivstruktur"
+            commonNamespace + ".Arkivstruktur.Minimum"
         },
         {
             new NamespaceKey("http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/noekler/v1"),
-            commonNamespace + ".Arkivstruktur"
+            commonNamespace + ".Arkivstruktur.Noekler"
         },
         {
             new NamespaceKey("https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1"),
-            commonNamespace + ".Arkivstruktur"
+            commonNamespace + ".Arkivstruktur.Noekler"
         },
         {
             new NamespaceKey("http://www.arkivverket.no/standarder/noark5/arkivstruktur"),


### PR DESCRIPTION
arkivstruktrukturlMinimum og arkivstrukturNoekler må ha egen namespace

Dette skyldes fordi vi introduserte/kopierte EksternNoekkel inn til arkivstrukturMinimum men de delte namespace i C#.
Da ble det krøll og vi fikk 1 EksternNoekkel med kun minimum som tilhørende xsd. 
Et annet alternativ er å ha EksternNoekkel kun i "vanlig" arkivstruktur og inkludere den i minimum og noekkel. Men usikker på om det kan skape annen trøbbel? 