### PR TITLE
xs:integer skal nå bli til int i C# generert kode #88

### DIFF
--- a/KS.Fiks.Arkiv.XsdModelGenerator/Generate.cs
+++ b/KS.Fiks.Arkiv.XsdModelGenerator/Generate.cs
@@ -11,6 +11,7 @@ var generator = new Generator
     Log = s => Console.Out.WriteLine(s),
     GenerateNullables = false,
     SeparateClasses = true,
+    IntegerDataType = typeof(int),
     NamespaceProvider = new NamespaceProvider
     {
         {


### PR DESCRIPTION
Fikser problemet med at xs:integer ble til string. 

xs:integer skal nå bli til int i C# generert kode ved å sette denne innstillingen i generatoren. [Issue #88](https://github.com/ks-no/fiks-arkiv/issues/88) 
