### PR TITLE
Manglet en meldingstype for mottat meldinger på arkivmelding oppdatering

### DIFF
--- a/KS.Fiks.Arkiv.Models.V1/Meldingstyper/FiksArkivMeldingtype.cs
+++ b/KS.Fiks.Arkiv.Models.V1/Meldingstyper/FiksArkivMeldingtype.cs
@@ -7,6 +7,7 @@ namespace KS.Fiks.Arkiv.Models.V1.Meldingstyper
         // Arkivering
         public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding";
         public const string ArkivmeldingOppdater = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater";
+        public const string ArkivmeldingOppdaterMottatt = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.mottatt";
         public const string ArkivmeldingOppdaterKvittering = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.kvittering";
         public const string ArkivmeldingMottatt = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.mottatt";
         public const string ArkivmeldingKvittering = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering";


### PR DESCRIPTION
La til den manglende meldingstypen i FiksArkivMeldingstype

Oppdaget at den manglet da vi skulle oppdatere integrasjonstestene til siste versjon av Fiks-Arkiv

