### PR TITLE
Add link to nuget package in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Skjemaene og spesifikasjonen er i følgende GitHub repository: https://github.co
 
 Der finnes også en [Wiki](https://github.com/ks-no/fiks-arkiv-specification/wiki) for Fiks Arkiv protokollen.
 
+#### Pakker:
+Nuget-pakken som er resultatet av github-prosjektet.
+- [KS.Fiks.Arkiv.Models.V1 (NuGet)](https://www.nuget.org/packages/KS.Fiks.Arkiv.Models.V1)


### PR DESCRIPTION
I spent few minutes searching for the package on NuGet. I tried using the GitHub repository name, `fiks-arkiv-models-dotnet` but it did not exist as we are using Pascal Case for the package. I taught it would be easier for the next person if the link to the NuGet package was in the Readme file